### PR TITLE
Use `<button>` elements for buttons, improve button accessibility #52 

### DIFF
--- a/public/assets/index.css
+++ b/public/assets/index.css
@@ -7,6 +7,8 @@
     --background-body: #202b38;
     --background: #161f27;
     --background-alt: #1a242f;
+    --background-button: #202b38;
+    --background-button-hover: #253240;
     --selection: #c0d5e8;
     --text-main: #e9f4fc;
     --text-bright: #c7d2dd;
@@ -299,11 +301,30 @@ a {
 .history-item h3 {
     font-size: 10px !important;
 }
+
+/* button style reset from https://css-tricks.com/overriding-default-button-styles/ */
+button {
+    color: inherit;
+    border: none;
+    background: none;
+    font-family: inherit;
+    font-size: 100%;
+    line-height: 1.15;
+    margin: 0;
+    overflow: visible;
+    text-transform: none;
+    -webkit-appearance: button;
+    text-align: inherit;
+}
 .button {
     padding: 8px 14px;
-    background-color: var(--background-body);
+    background-color: var(--background-button);
     border-radius: 900px;
     cursor: pointer;
+    text-align: center;
+}
+.button:hover {
+    background-color: var(--background-button-hover);
 }
 
 .tools {
@@ -337,12 +358,14 @@ light {
     background-color: #fff1;
     border-radius: 32px;
     position: relative;
+    flex-shrink: 0; /* Fix deformed circle on narrow screens */
 }
 
 .toggle {
     margin-right: 12px;
     display: flex;
     align-items: center;
+    cursor: pointer;
 }
 
 .toggle-enabled .toggle-box:after {
@@ -490,6 +513,9 @@ footer img {
     top: 50px;
     left: 50px;
     cursor: pointer;
+}
+.large-counter-close:hover {
+    background-color: #fff6;
 }
 
 .odometer.odometer-auto-theme,

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,7 @@
     <title>Reddark</title>
     <meta name="google-site-verification" content="U_FcRrVYPOtB9T7cs7klW5ioWQhkLbKyWH3H8AGK_es"/>
     <meta name="description" content="An open source website to watch subreddits going dark">
-    <link rel="stylesheet" href="/assets/index.css?z=1">
+    <link rel="stylesheet" href="/assets/index.css?z=2">
     <link rel="icon"
           href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 115 115%22><text y=%22.9em%22 font-size=%2290%22>✊</text></svg>">
 </head>

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,7 +12,7 @@
 </head>
 <body>
 <div class="large-counter large-counter-hidden" id="large-counter">
-    <div class="large-counter-close" onclick="toggleLargeCounter()">X</div>
+    <button class="large-counter-close" onclick="toggleLargeCounter()">X</button>
     <div class="large-counter-inner">
         <h1><span class="odemeter" id="lc-count">{{dark_subs}}</span><small id="lc-max"> <light>out of</light> <span id="lc-total">{{total_subs}}</span></small></h1>
         <div class="progress">
@@ -114,17 +114,17 @@
 
 <div class="tools">
     <div class="tools-inner">
-        <div class="toggle" onclick="hidePublicSubreddits()" id="hide-public">
+        <button class="toggle" onclick="hidePublicSubreddits()" id="hide-public">
             <div class="toggle-box"></div>
             <p>Hide public subreddits</p>
-        </div>
-        <div class="toggle" onclick="hidePrivateSubreddits()" id="hide-private">
+        </button>
+        <button class="toggle" onclick="hidePrivateSubreddits()" id="hide-private">
             <div class="toggle-box"></div>
             <p>Hide private subreddits</p>
-        </div>
+        </button>
         <div class="tools-left">
-            <div class="button" onclick="toggleLargeCounter()">Large counter</div>
-            <div class="button" id="enable_sounds">Enable sound alerts</div>
+            <button class="button" onclick="toggleLargeCounter()">Large counter</button>
+            <button class="button" id="enable_sounds">Enable sound alerts</button>
         </div>
     </div>
 </div>


### PR DESCRIPTION
This changes the buttons to use `<button>` tags so that you can use them using the keyboard.  It also adds `cursor: pointer` styles to the toggle buttons and large counter close button, and makes the background colors of most buttons change on hover.

(I've tested the button styling, and it's consistent on Chrome, Firefox, and Safari)

Ported from Tanza3D/reddark#52