### PR TITLE
updated my third party fork link

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -133,7 +133,7 @@
             <p>In case this site is down, these are some third party instances you can use instead. These aren't hosted
                 by
                 us, so the contents could possibly be malicious, click with caution.</p>
-            <a href="https://reddark-digitalocean-7lhfr.ondigitalocean.app/">https://reddark-digitalocean-7lhfr.ondigitalocean.app/</a>
+            <a href="https://reddark.io/">https://reddark.io/</a>
         </div>
     </div>
 </header>


### PR DESCRIPTION
my fork has now changed url from the one ending `.digitalocean.app` to [reddark.io](https://reddark.io/) (with the former redirecting to the latter)

submitting a pr to change the link to it on the main instance