### PR TITLE
updated wording of page header

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -48,7 +48,7 @@
             href="https://twitch.tv/reddark_247">twitch.tv/reddark_247!</a></small>
     <h1>✊ Reddark</h1>
 
-    <h2>These subreddits went dark between June 12th and June 14th. Some are remaining that way indefinitely. Click <a
+    <h2>These subreddits went dark between June 12th and June 14th. Many are remaining that way indefinitely. Click <a
             href="https://www.theverge.com/2023/6/5/23749188/reddit-subreddit-private-protest-api-changes-apollo-charges"
             title="Major Reddit communities will go dark to protest threat to third-party apps">here</a>
         to find out why.</h2>

--- a/templates/index.html
+++ b/templates/index.html
@@ -48,7 +48,7 @@
             href="https://twitch.tv/reddark_247">twitch.tv/reddark_247!</a></small>
     <h1>✊ Reddark</h1>
 
-    <h2>These subreddits went dark between June 12th and June 14th, and some are remaining that way indefinitely. Click <a
+    <h2>These subreddits went dark between June 12th and June 14th. Some are remaining that way indefinitely. Click <a
             href="https://www.theverge.com/2023/6/5/23749188/reddit-subreddit-private-protest-api-changes-apollo-charges"
             title="Major Reddit communities will go dark to protest threat to third-party apps">here</a>
         to find out why.</h2>

--- a/templates/index.html
+++ b/templates/index.html
@@ -48,7 +48,7 @@
             href="https://twitch.tv/reddark_247">twitch.tv/reddark_247!</a></small>
     <h1>✊ Reddark</h1>
 
-    <h2>These subreddits are going dark or read-only on June 12th and after. Some already are. Click <a
+    <h2>These subreddits went dark between June 12th and June 14th, and some are remaining that way indefinitely. Click <a
             href="https://www.theverge.com/2023/6/5/23749188/reddit-subreddit-private-protest-api-changes-apollo-charges"
             title="Major Reddit communities will go dark to protest threat to third-party apps">here</a>
         to find out why.</h2>


### PR DESCRIPTION
updated the wording of the page header so it’s up-to-date

changed from: `These subreddits are going dark or read-only on June 12th and after. Some already are.`

to: `These subreddits went dark between June 12th and June 14th. Many are remaining that way indefinitely.`

if there’s any changes you’d like to the wording then let me know