### PR TITLE
Use "swapped to" if switching between private and restricted

### DIFF
--- a/public/assets/index.js
+++ b/public/assets/index.js
@@ -9,6 +9,8 @@ var audioSystem = {
 
 var block = ["r/gtafk","r/bi_irl", "r/suddenlybi", "r/ennnnnnnnnnnnbbbbbby", "r/feemagers", "r/BrexitAteMyFace", "r/emoney", "r/Inzaghi"];
 
+var blackedOutStates = ["PRIVATE", "RESTRICTED"];
+
 document.getElementById("enable_sounds").addEventListener("click", function () {
     if (!audioSystem.playAudio) {
         this.innerHTML = "Disable sound alerts"
@@ -124,7 +126,9 @@ function handleDeltaUpdate(message) {
         return;
     }
 
-    var text = `<strong>${message["name"]}</strong> has gone ${mapState(message["state"])}! (${message["section"]})`;
+    // True if swapped between PRIVATE and RESTRICTED, false if not
+    var swapped = (blackedOutStates.includes(message["state"]) && blackedOutStates.includes(message["previous_state"]));
+    var text = `<strong>${message["name"]}</strong> ${swapped ? 'swapped to' : 'has gone'} ${mapState(message["state"])}! (${message["section"]})`;
 
     // Send out status update for people not in large counter mode.
     newStatusUpdate(text, function () {
@@ -163,7 +167,7 @@ function handleDeltaUpdate(message) {
 
     var history_item = Object.assign(document.createElement("div"), {className: "history-item n" + sectionBaseName(message["section"])});
     var t = new Date().toISOString().replace("T", " ").replace(/\..+/, '');
-    history_item.innerHTML = `<h1><strong>${message["name"]}</strong> has gone ${mapState(message["state"])}! (${message["section"]})</h1><h3>${t}</h3>`;
+    history_item.innerHTML = `<h1>${text}</h1><h3>${t}</h3>`;
 
     switch (message["state"]) {
         case "PUBLIC":

--- a/public/assets/index.js
+++ b/public/assets/index.js
@@ -167,7 +167,11 @@ function handleDeltaUpdate(message) {
 
     var history_item = Object.assign(document.createElement("div"), {className: "history-item n" + sectionBaseName(message["section"])});
     var t = new Date().toISOString().replace("T", " ").replace(/\..+/, '');
-    history_item.innerHTML = `<h1>${text}</h1><h3>${t} | was ${mapState(message["previous_state"])}</h3>`;
+    var last = '';
+    if (message["previous_state"] != "UNKNOWN") {
+        last = ` | was ${mapState(message["previous_state"])}`;
+    }
+    history_item.innerHTML = `<h1>${text}</h1><h3>${t}${last}</h3>`;
 
     switch (message["state"]) {
         case "PUBLIC":

--- a/public/assets/index.js
+++ b/public/assets/index.js
@@ -167,7 +167,7 @@ function handleDeltaUpdate(message) {
 
     var history_item = Object.assign(document.createElement("div"), {className: "history-item n" + sectionBaseName(message["section"])});
     var t = new Date().toISOString().replace("T", " ").replace(/\..+/, '');
-    history_item.innerHTML = `<h1>${text}</h1><h3>${t}</h3>`;
+    history_item.innerHTML = `<h1>${text}</h1><h3>${t} | was ${mapState(message["previous_state"])}</h3>`;
 
     switch (message["state"]) {
         case "PUBLIC":

--- a/templates/index.html
+++ b/templates/index.html
@@ -43,7 +43,11 @@
                 {{subreddit["state"] | lower}}! ({{subreddit["section"]}})
             </h1>
         {%- set ts = item["timestamp"]|replace(from="T", to=" ")|split(pat=".") %}
-        <h3>{{ts[0]}} | was {{item["prev_state"] | lower}}</h3>
+        <h3>{{ts[0]}}
+        {%- if item["prev_state"] != "UNKNOWN" %}
+         | was {{item["prev_state"] | lower}}
+        {%- endif %}
+        </h3>
         </div>
         {%- endfor %}
     </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,13 +28,19 @@
         </div>
     </div>
     <div class="large-counter-history" id="counter-history">
+        {%- set blacked_out_states = ["PRIVATE", "RESTRICTED"] %}
         {%- for item in history %}
         {%- set subreddit = item["subreddit"] %}
         {%- set basesect = subreddit["section"]|replace(from=" ", to="")|replace(from=":", to="")|replace(from="+", to="")|replace(from=" ", to="")|replace(from="\r", to="")|replace(from="\n", to="") %}
         <div class="history-item n{{basesect}} {% if subreddit["state"] == "PUBLIC" %}history-item-online{% endif %}">
             <h1>
                 <strong>{{subreddit["name"]}}</strong>
-                has gone {{subreddit["state"] | lower}}! ({{subreddit["section"]}})
+                {%- if blacked_out_states is containing(subreddit["state"]) and blacked_out_states is containing(item["prev_state"]) %}
+                 swapped to 
+                {% else %}
+                 has gone 
+                {% endif -%}
+                {{subreddit["state"] | lower}}! ({{subreddit["section"]}})
             </h1>
         {%- set ts = item["timestamp"]|replace(from="T", to=" ")|split(pat=".") %}
         <h3>{{ts[0]}}</h3>

--- a/templates/index.html
+++ b/templates/index.html
@@ -43,7 +43,7 @@
                 {{subreddit["state"] | lower}}! ({{subreddit["section"]}})
             </h1>
         {%- set ts = item["timestamp"]|replace(from="T", to=" ")|split(pat=".") %}
-        <h3>{{ts[0]}}</h3>
+        <h3>{{ts[0]}} | was {{item["prev_state"] | lower}}</h3>
         </div>
         {%- endfor %}
     </div>


### PR DESCRIPTION
If the state is from restricted to private, or private to restricted, use "swapped to" wording to indicate they are still "blacked out" anyway.

Public to restricted, private, or vice versa still uses "has gone".

Also adds the previous state to the large counter, but if you prefer that can be removed as it's a separate commit

This is to give more information to readers as to how the subreddit changed. The current blackout has a lot of infighting with moderators and it would be nice to clarify whether a subreddit is coming out of the blackout or just switching between private and restricted.

![Screenshot_20230617_030347](https://github.com/reddark-remix/reddark-remix/assets/5211576/53b0c08e-7145-4d3f-9a98-693eb82e4f39)

![Screenshot_20230617_0
24815](https://github.com/reddark-remix/reddark-remix/assets/5211576/a29468d6-6a48-4c0d-aa3a-0a48d80686b1)


